### PR TITLE
Bug fix bottom banner rotation

### DIFF
--- a/McAdViewControllerExample/McAdViewController.swift
+++ b/McAdViewControllerExample/McAdViewController.swift
@@ -121,7 +121,6 @@ open class McAdViewController : UIViewController {
         contentController.view.frame = controllerFrame
     }
 
-    
     private func makeBannerChanges(bannerAdView:GADBannerView) {
         var contentFrame:CGRect = self.view.bounds
         var bannerFrame:CGRect = bannerAdView.frame
@@ -257,9 +256,11 @@ extension McAdViewController : GADInterstitialDelegate {
     public func interstitialWillDismissScreen(_ ad: GADInterstitial) {
         prepareInterstantialAd()
     }
+    
     public func interstitialDidReceiveAd(_ ad: GADInterstitial) {
         printDebug("Interstitial - DidReceiveAd")
     }
+    
     public func interstitial(_ ad: GADInterstitial, didFailToReceiveAdWithError error: GADRequestError) {
         printDebug("Interstitial - didFailToReceiveAdWithError \(error)")
         

--- a/McAdViewControllerExample/McAdViewController.swift
+++ b/McAdViewControllerExample/McAdViewController.swift
@@ -195,7 +195,7 @@ extension McAdViewController : GADBannerViewDelegate {
             bannerAdView!.adUnitID = bannerAdUnitId
             bannerAdView!.rootViewController = self
             bannerAdView!.delegate = self
-            setBannerSmartSize(size: CGSize(width: self.view.bounds.size.width, height: self.view.bounds.size.height))
+            setBannerSmartSize(size: self.view.bounds.size)
         }
 
         return bannerAdView

--- a/McAdViewControllerExample/McAdViewController.swift
+++ b/McAdViewControllerExample/McAdViewController.swift
@@ -87,10 +87,10 @@ open class McAdViewController : UIViewController {
         
         self.view = contentView
     }
-    
-    open override func viewDidLoad() {
-        super.viewDidLoad()
-        
+
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
         // Setup Ads if needed
         //
         prepareInterstantialAd()


### PR DESCRIPTION
Fixed an issue when presenting non-root vc, then rotate device, then dismiss the non-root vc. banner ad would not update. This left an empty black box.